### PR TITLE
fix datetime updated_at default value

### DIFF
--- a/aiogram_bot_template/services/database/models/base.py
+++ b/aiogram_bot_template/services/database/models/base.py
@@ -15,7 +15,7 @@ class Base(DeclarativeBase):
 class TimestampMixin:
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
-        default=datetime.now(timezone.utc),
+        default=lambda: datetime.now(timezone.utc),
         onupdate=func.now(),
         server_default=func.now(),
     )

--- a/aiogram_bot_template/services/database/models/base.py
+++ b/aiogram_bot_template/services/database/models/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated, TypeAlias
 
 from sqlalchemy import BigInteger, Integer, func
@@ -15,7 +15,7 @@ class Base(DeclarativeBase):
 class TimestampMixin:
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
-        default=func.now(),
+        default=datetime.now(timezone.utc),
         onupdate=func.now(),
         server_default=func.now(),
     )


### PR DESCRIPTION
func.now() cannot be used in ‘default’ arg. Because it is DB function. default - for Python code that executes before send request to DB. Change func.now() to Python datetime.now() or use it in server_default

_Originally posted by @xnuinside in https://github.com/aminalaee/sqladmin/issues/195#issuecomment-1236371063_
            